### PR TITLE
Support running on PHP 7.0-8.2

### DIFF
--- a/cli.class.php
+++ b/cli.class.php
@@ -173,6 +173,9 @@
 		}
 		
 		public function errorHandler($errType, $errStr, $errFile, $errLine) {
+			if($errType == E_DEPRECATED || $errType == E_STRICT)
+				return false;
+
 			if($this->inExecute)
 				throw new MoodyException($errStr, $errType);
 			

--- a/token.class.php
+++ b/token.class.php
@@ -43,84 +43,6 @@
         public $instruction = "";
 		private static $tokens = 0;
 		private static $files = 0;
-		private static $typeNames = array(
-				T_ABSTRACT => "T_ABSTRACT",
-				T_AND_EQUAL => "T_AND_EQUAL",
-				T_ARRAY => "T_ARRAY",
-				T_ARRAY_CAST => "T_ARRAY_CAST",
-				T_AS => "T_AS",
-				T_BAD_CHARACTER => "T_BAD_CHARACTER",
-				T_BOOLEAN_AND => "T_BOOLEAN_AND",
-				T_BOOLEAN_OR => "T_BOOLEAN_OR",
-				T_BOOL_CAST => "T_BOOL_CAST",
-				T_BREAK => "T_BREAK",
-				T_CASE => "T_CASE",
-				T_CATCH => "T_CATCH",
-				T_CHARACTER => "T_CHARACTER",
-				T_CLASS => "T_CLASS",
-				T_CLASS_C => "T_CLASS_C",
-				T_CLONE => "T_CLONE",
-				T_CLOSE_TAG => "T_CLOSE_TAG",
-				T_COMMA => "T_COMMA",
-				T_COMMENT => "T_COMMENT",
-				T_CONCAT_EQUAL => "T_CONCAT_EQUAL",
-				T_CONST => "T_CONST",
-				T_CONSTANT_ENCAPSED_STRING => "T_CONSTANT_ENCAPSED_STRING",
-				T_CONTINUE => "T_CONTINUE",
-				T_CURLY_OPEN => "T_CURLY_OPEN",
-				T_CURLY_BRACKET_OPEN => "T_CURLY_BRACKET_OPEN",
-				T_CURLY_BRACKET_CLOSE => "T_CURLY_BRACKET_CLOSE",
-				T_DEC => "T_DEC",
-				T_DECLARE => "T_DECLARE",
-				T_DEFAULT => "T_DEFAULT",
-				T_DIR => "T_DIR",
-				T_DIV_EQUAL => "T_DIV_EQUAL",
-				T_DNUMBER => "T_DNUMBER",
-				T_DO => "T_DO",
-				T_DOC_COMMENT => "T_DOC_COMMENT",
-				T_DOLLAR_OPEN_CURLY_BRACES => "T_DOLLAR_OPEN_CURLY_BRACES",
-				T_DOT => "T_DOT",
-				T_DOUBLE_ARROW => "T_DOUBLE_ARROW",
-				T_DOUBLE_CAST => "T_DOUBLE_CAST",
-				T_DOUBLE_COLON => "T_DOUBLE_COLON",
-				T_ECHO => "T_ECHO",
-				T_ELSE => "T_ELSE",
-				T_ELSEIF => "T_ELSEIF",
-				T_EMPTY => "T_EMPTY",
-				T_ENCAPSED_AND_WHITESPACE => "T_ENCAPSED_AND_WHITESPACE",
-				T_ENDDECLARE => "T_ENDDECLARE",
-				T_ENDFOR => "T_ENDFOR",
-				T_ENDFOREACH => "T_ENDFOREACH",
-				T_ENDIF => "T_ENDIF",
-				T_ENDSWITCH => "T_ENDSWITCH",
-				T_ENDWHILE => "T_ENDWHILE",
-				T_END_HEREDOC => "T_END_HEREDOC",
-				T_EOF => "T_EOF",
-				T_EQUAL => "T_EQUAL",
-				T_EVAL => "T_EVAL",
-				T_EXIT => "T_EXIT",
-				T_EXTENDS => "T_EXTENDS",
-				T_FALSE => "T_FALSE",
-				T_FILE => "T_FILE",
-				T_FINAL => "T_FINAL",
-				T_FOR => "T_FOR",
-				T_FORCED_WHITESPACE => "T_FORCED_WHITESPACE",
-				T_FOREACH => "T_FOREACH",
-				T_FUNCTION => "T_FUNCTION",
-				T_FUNC_C => "T_FUNC_C",
-				T_GLOBAL => "T_GLOBAL",
-				T_GOTO => "T_GOTO",
-				T_HALT_COMPILER => "T_HALT_COMPILER",
-				T_OPEN_TAG => "T_OPEN_TAG",
-				T_ROUND_BRACKET_CLOSE => "T_ROUND_BRACKET_CLOSE",
-				T_ROUND_BRACKET_OPEN => "T_ROUND_BRACKET_OPEN",
-				T_SEMICOLON => "T_SEMICOLON",
-				T_STRING => "T_STRING",
-				T_TRUE => "T_TRUE",
-				T_UNKNOWN => "T_UNKNOWN",
-				T_VARIABLE => "T_VARIABLE",
-				T_WHITESPACE => "T_WHITESPACE"
-				/* To be continued */);
 		
 		public function __construct() {
 			$this->id = self::$tokens++;
@@ -205,7 +127,7 @@
 		}
 		
 		public static function getName($tokenType) {
-			return isset(self::$typeNames[$tokenType]) ? self::$typeNames[$tokenType] : $tokenType;
+			return token_name($tokenType) == "UNKNOWN" ? $tokenType : token_name($tokenType);
 		}
 		
 		public function __toString() {


### PR DESCRIPTION
PHP 7.0 dropped the `T_CHARACTER` and `T_BAD_CHARACTER` tokens, leading to Undefined constant errors. Fix by just using `token_name()`.

For full PHP 7.0+ compat also depends on #4. Alternatively we could disable `compressproperties` in `build.php`.

Either commit fixes #1 but both are preferred.