### PR TITLE
Fix all new Tokens

### DIFF
--- a/cli.class.php
+++ b/cli.class.php
@@ -122,6 +122,7 @@
 				$token = new Token;
 				$token->type = T_EOF;
 				$token->fileName = $origin;
+				$tokenArray[] = $token;
 			}
 			$source = $this->executeScript($tokenArray);
 			

--- a/instructionHandlers/include.php
+++ b/instructionHandlers/include.php
@@ -48,6 +48,7 @@
 					$token = new Token;
 					$token->type = T_CLOSE_TAG;
 					$token->content = " ?>";
+					$token->fileName = $args[0];
 					$tokensN = array($token);
 					foreach($tokens as $token)
 						$tokensN[] = $token;
@@ -62,13 +63,14 @@
 					$token = new Token;
 					$token->type = T_OPEN_TAG;
 					$token->content = "<?php ";
+					$token->fileName = $args[0];
 					$tokens[] = $token;
 			}
 			
 			// Add T_EOF
 			$token = new Token;
 			$token->type = T_EOF;
-			$token->content = $args[0];
+			$token->fileName = $args[0];
 			$tokens[] = $token;
 
 			$vm->insertTokenArray($tokens);


### PR DESCRIPTION
- Fixes bug in cli.class.php where token was not inserted into tokenArray. Note there is another bug that cli.class.php assumes it can access the properties of a `Token` object, but `build.php` renames all properties by default. Even if the T_EOF token is inserted it has no use, since its real type property will still be 0, which is not a known token type and should not have any handlers registered for it. Workaround is building Moody with `--fastbuild`. For proper fix depends on https://github.com/pp3345/Moody/pull/4 or needs `compressproperties` set to false.

- In include.php tokens were created without fileName, in one case fileName was placed into content